### PR TITLE
Rename the urg_c library and make it shared.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(ament_cmake REQUIRED)
 include_directories(${LIBRARY_INCLUDE_DIR})
 
 ## Declare libraries
-add_library(liburg_c ${LIBRARY_SRC_DIR}/urg_sensor.c
+add_library(urg_c SHARED ${LIBRARY_SRC_DIR}/urg_sensor.c
 	                 ${LIBRARY_SRC_DIR}/urg_utils.c
 	                 ${LIBRARY_SRC_DIR}/urg_debug.c
 	                 ${LIBRARY_SRC_DIR}/urg_connection.c
@@ -36,52 +36,52 @@ add_library(liburg_c ${LIBRARY_SRC_DIR}/urg_sensor.c
 
 )
 if(CMAKE_COMPILER_IS_GNUCXX)
-	target_link_libraries(liburg_c -lrt -lm)
+	target_link_libraries(urg_c -lrt -lm)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 add_library(open_urg_sensor ${LIBRARY_SAMPLE_DIR}/open_urg_sensor.c)
-target_link_libraries(open_urg_sensor -lm liburg_c)
+target_link_libraries(open_urg_sensor -lm urg_c)
 
 ## Declare samples
 add_executable(angle_convert_test ${LIBRARY_SAMPLE_DIR}/angle_convert_test.c)
-target_link_libraries(angle_convert_test liburg_c open_urg_sensor)
+target_link_libraries(angle_convert_test urg_c open_urg_sensor)
 
 add_executable(calculate_xy ${LIBRARY_SAMPLE_DIR}/calculate_xy.c)
-target_link_libraries(calculate_xy liburg_c open_urg_sensor)
+target_link_libraries(calculate_xy urg_c open_urg_sensor)
 
 add_executable(find_port ${LIBRARY_SAMPLE_DIR}/find_port.c)
-target_link_libraries(find_port liburg_c open_urg_sensor)
+target_link_libraries(find_port urg_c open_urg_sensor)
 
 add_executable(get_distance ${LIBRARY_SAMPLE_DIR}/get_distance.c)
-target_link_libraries(get_distance liburg_c open_urg_sensor)
+target_link_libraries(get_distance urg_c open_urg_sensor)
 
 add_executable(get_distance_intensity ${LIBRARY_SAMPLE_DIR}/get_distance_intensity.c)
-target_link_libraries(get_distance_intensity liburg_c open_urg_sensor)
+target_link_libraries(get_distance_intensity urg_c open_urg_sensor)
 
 add_executable(get_multiecho ${LIBRARY_SAMPLE_DIR}/get_multiecho.c)
-target_link_libraries(get_multiecho liburg_c open_urg_sensor)
+target_link_libraries(get_multiecho urg_c open_urg_sensor)
 
 add_executable(get_multiecho_intensity ${LIBRARY_SAMPLE_DIR}/get_multiecho_intensity.c)
-target_link_libraries(get_multiecho_intensity liburg_c open_urg_sensor)
+target_link_libraries(get_multiecho_intensity urg_c open_urg_sensor)
 
 add_executable(reboot_test ${LIBRARY_SAMPLE_DIR}/reboot_test.c)
-target_link_libraries(reboot_test liburg_c open_urg_sensor)
+target_link_libraries(reboot_test urg_c open_urg_sensor)
 
 add_executable(sensor_parameter ${LIBRARY_SAMPLE_DIR}/sensor_parameter.c)
-target_link_libraries(sensor_parameter liburg_c open_urg_sensor)
+target_link_libraries(sensor_parameter urg_c open_urg_sensor)
 
 add_executable(sync_time_stamp ${LIBRARY_SAMPLE_DIR}/sync_time_stamp.c)
-target_link_libraries(sync_time_stamp liburg_c open_urg_sensor)
+target_link_libraries(sync_time_stamp urg_c open_urg_sensor)
 
 add_executable(timeout_test ${LIBRARY_SAMPLE_DIR}/timeout_test.c)
-target_link_libraries(timeout_test liburg_c open_urg_sensor)
+target_link_libraries(timeout_test urg_c open_urg_sensor)
 
 #############
 ## Install ##
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS liburg_c open_urg_sensor angle_convert_test calculate_xy find_port
+install(TARGETS urg_c open_urg_sensor angle_convert_test calculate_xy find_port
                 get_distance get_distance_intensity get_multiecho get_multiecho_intensity
 	            reboot_test sensor_parameter sync_time_stamp timeout_test
   ARCHIVE DESTINATION lib
@@ -95,5 +95,5 @@ install(DIRECTORY ${LIBRARY_INCLUDE_DIR}/${PROJECT_NAME}/
 )
 
 ament_export_include_directories(include)
-ament_export_libraries(liburg_c open_urg_sensor)
+ament_export_libraries(urg_c open_urg_sensor)
 ament_package()


### PR DESCRIPTION
The CMake target was named "liburg_c", which means that the
final library was "libliburg_c", which is just weird.  Rename
the target to urg_c, and also mark it as SHARED so it works
when building as a component.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@Karsten1987 FYI this is part of the changes I needed to get the whole URG stack building on Linux.